### PR TITLE
Add FoxPro DBC backlink, export APIs, and header tests

### DIFF
--- a/src/DBase/DbfFieldDescriptorExtensions.cs
+++ b/src/DBase/DbfFieldDescriptorExtensions.cs
@@ -9,13 +9,12 @@ internal static class DbfFieldDescriptorExtensions
     {
         public DbfTableFlags GetTableFlags()
         {
-            var flags = DbfTableFlags.None;
-            if (descriptors.Any(descriptor => descriptor.Type == DbfFieldType.Memo))
+            if (descriptors.Any(descriptor => descriptor.Type is DbfFieldType.Binary or DbfFieldType.Blob or DbfFieldType.Memo))
             {
-                flags |= DbfTableFlags.HasMemoField;
+                return DbfTableFlags.HasMemoField;
             }
 
-            return flags;
+            return DbfTableFlags.None;
         }
 
         public void EnsureFieldOffsets()

--- a/src/DBase/DbfRecord.cs
+++ b/src/DBase/DbfRecord.cs
@@ -51,7 +51,7 @@ public readonly record struct DbfRecord : IReadOnlyList<DbfField>
         Fields = fields;
     }
 
-    private string GetDebuggerDisplay() => $"{nameof(Count)} = {Count}";
+    private string GetDebuggerDisplay() => $"[{string.Join(", ", Fields.Select(x => x.ToString()))}]";
 
     /// <summary>
     /// Returns an enumerator that iterates through the fields.

--- a/src/DBase/Memo.cs
+++ b/src/DBase/Memo.cs
@@ -92,6 +92,28 @@ public sealed class Memo : IDisposable, IEnumerable<MemoRecord>
         return new Memo(stream, version);
     }
 
+    /// <summary>
+    /// Saves the current <see cref="Memo"/> to a new file with the specified file name.
+    /// </summary>
+    /// <param name="fileName">The name of the file to which the data will be saved.</param>
+    public void Save(string fileName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        using var memo = new FileStream(fileName, FileMode.CreateNew, FileAccess.ReadWrite);
+        WriteTo(memo);
+    }
+
+    /// <summary>
+    /// Writes the current <see cref="Memo"/> to the specified stream.
+    /// </summary>
+    /// <param name="stream">The stream to which the contents will be written to.</param>
+    public void WriteTo(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        _memo.Position = 0;
+        _memo.CopyTo(stream);
+    }
+
     private static (int nextIndex, ushort blockLength) ReadHeaderInfo(Stream stream, DbfVersion version)
     {
         stream.Position = 0;

--- a/src/DBase/Serialization/DbcBacklink.cs
+++ b/src/DBase/Serialization/DbcBacklink.cs
@@ -1,0 +1,62 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace DBase.Serialization;
+
+/// <summary>
+/// Represents the Visual FoxPro database container (DBC) backlink area stored in a DBF file header.
+/// </summary>
+/// <remarks>
+/// <para>
+/// In Visual FoxPro–style DBF files (versions 0x30, 0x31, 0x32), a table may optionally be associated with
+/// a database container (<c>.dbc</c> file). When present, the DBF header reserves a 263-byte <em>backlink</em>
+/// area immediately after the field descriptor terminator (<c>0x0D</c>) and before the first data record.
+/// </para>
+/// <para>
+/// The backlink area is FoxPro-specific and not formally specified; it should be treated as an opaque blob.
+/// Many files store one or more null-terminated strings within this area (often including the DBC path and
+/// the table name as registered in the database container), but this is not guaranteed for all producers.
+/// </para>
+/// </remarks>
+[InlineArray(263)]
+public struct DbcBacklink
+{
+    private byte _e0;
+
+    /// <summary>
+    /// Represents an empty backlink is present.
+    /// </summary>
+    public static readonly DbcBacklink Empty = default;
+
+    /// <summary>
+    /// Gets the database container path (<c>.dbc</c>) decoded from the backlink area, if available.
+    /// </summary>
+    /// <remarks>
+    /// This value is extracted on a best-effort basis from the backlink data and may be <see langword="null" />
+    /// if the table is not bound to a database container or if the content is not in the expected form.
+    /// </remarks>
+    public string? DbcPath => GetNullTerminatedStringAtOrDefault(0);
+
+    /// <summary>
+    /// Gets the logical table name decoded from the backlink area, if available.
+    /// </summary>
+    /// <remarks>
+    /// This value is extracted on a best-effort basis from the backlink data and may be <see langword="null" />
+    /// if the content is not in the expected form.
+    /// </remarks>
+    public string? TableName => GetNullTerminatedStringAtOrDefault(1);
+
+    private string? GetNullTerminatedStringAtOrDefault(int index)
+    {
+        Span<byte> span = this;
+        var i = 0;
+        using var enumerator = span.Split((byte)0);
+        do
+        {
+            if (!enumerator.MoveNext())
+                return null;
+        } while (i++ < index);
+
+        return Encoding.UTF8.GetString(span[enumerator.Current]);
+    }
+}

--- a/tests/DBase.Tests/DBaseTest`1.cs
+++ b/tests/DBase.Tests/DBaseTest`1.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using CsvHelper;
+using Xunit.Sdk;
 
 namespace DBase.Tests;
 
@@ -55,5 +56,103 @@ public abstract class DBaseTest<T> : DBaseTest
         }
 
         return Encoding.UTF8.GetString(output.ToArray());
+    }
+
+    [Fact]
+    public void RoundtripHeader()
+    {
+        using var source = Dbf.Open(DbfPath);
+        using var oldDbf = new MemoryStream();
+        using var oldMemo = new MemoryStream();
+        source.WriteTo(oldDbf, oldMemo);
+
+        var target = Dbf.Create(
+            new MemoryStream(),
+            source.Descriptors,
+            source.Memo is not null ? new MemoryStream() : null,
+            source.Version,
+            source.Language);
+
+        foreach (var record in source.EnumerateRecords<T>())
+            target.Add(record);
+
+        using var newDbf = new MemoryStream();
+        using var newMemo = new MemoryStream();
+        target.WriteTo(newDbf, newMemo);
+
+        var expected = oldDbf.ToArray().AsSpan();
+        var actual = newDbf.ToArray().AsSpan();
+
+        var version = source.Version;
+        if (version is DbfVersion.DBase02)
+        {
+            AssertBytes(expected, actual, 0..1, "version");
+            AssertBytes(expected, actual, 1..3, "record count");
+            // AssertBytes(expected, actual, 3..6, "last update");
+            AssertBytes(expected, actual, 6..8, "record length");
+        }
+        else
+        {
+            AssertBytes(expected, actual, 0..1, "version");
+            // AssertBytes(expected, actual, 1..4, "last update");
+            AssertBytes(expected, actual, 4..8, "record count");
+            AssertBytes(expected, actual, 8..10, "header length");
+            AssertBytes(expected, actual, 10..12, "record length");
+            AssertBytes(expected, actual, 28..29, "flags", GetTableFlagsComparer());
+            AssertBytes(expected, actual, 29..30, "language");
+        }
+
+        return;
+
+        static EqualityComparer<byte[]> GetTableFlagsComparer() => EqualityComparer<byte[]>.Create(
+            (x, y) =>
+            {
+                if (x?.Length != 1 || y?.Length != 1) return false;
+                var a = x[0] & ~(int)DbfTableFlags.HasStructuralCdx;
+                var b = y[0] & ~(int)DbfTableFlags.HasStructuralCdx;
+                return a == b;
+            },
+            obj =>
+            {
+                if (obj.Length != 1) return 0;
+                return obj[0] & ~(int)DbfTableFlags.HasStructuralCdx;
+            });
+    }
+
+    private static void AssertBytes(ReadOnlySpan<byte> expected, ReadOnlySpan<byte> actual, Range range, string label, IEqualityComparer<byte[]>? comparer = null)
+    {
+        try
+        {
+            if (comparer is not null)
+            {
+                Assert.Equal(expected[range].ToArray(), actual[range].ToArray(), comparer);
+            }
+            else
+            {
+                Assert.Equal(expected[range], actual[range]);
+            }
+        }
+        catch (XunitException ex)
+        {
+            throw new XunitException($"Value '{label}' mismatch ({range.Start.Value}..{range.End.Value}):\n{ex.Message}");
+        }
+    }
+
+    private static int AssertEqualDescriptors(DbfVersion version, ReadOnlySpan<byte> expected, ReadOnlySpan<byte> actual)
+    {
+        if (version is DbfVersion.DBase02)
+        {
+            Assert.Equal(expected[0..1], actual[0..1]); // Version
+            Assert.Equal(expected[1..3], actual[1..3]); // Record count
+            if (expected[3..6] is not [0, 0, 0])
+                Assert.Equal(expected[3..6], actual[3..6]); // Last update
+            Assert.Equal(expected[6..8], actual[6..8]); // Record length
+
+            return 8;
+        }
+        else
+        {
+            return 32;
+        }
     }
 }


### PR DESCRIPTION
- Add DbcBacklink struct and FoxPro backlink reading to Dbf
- Add SaveAs/WriteTo methods for Dbf and Memo export to file/stream
- Simplify DbfHeader construction with new constructor
- Improve table flag logic for Binary/Blob/Memo fields
- Add header roundtrip test and byte comparison helpers
- Enhance DbfRecord debugger display and update docs