### PR TITLE
Refactor DBF header IO and add stream endianness tests

### DIFF
--- a/src/DBase/CodeGen/RecordGenerator.cs
+++ b/src/DBase/CodeGen/RecordGenerator.cs
@@ -152,7 +152,8 @@ internal static partial class RecordGenerator
     private static ImmutableArray<DbfFieldDescriptor> ReadDescriptors(string dbfPath)
     {
         using var stream = File.OpenRead(dbfPath);
-        return Dbf.ReadHeader(stream).descriptors;
+        var header = Dbf.ReadHeader(stream);
+        return Dbf.ReadDescriptors(stream, header.Version);
     }
 
     private static string GetTypeName(string dbfPath, bool pascalCase) =>

--- a/src/DBase/Interop/StreamExtensions.cs
+++ b/src/DBase/Interop/StreamExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -6,51 +6,45 @@ namespace DBase.Interop;
 
 internal static class StreamExtensions
 {
+    private static class FieldOffsets<T> where T : unmanaged
+    {
+        public static readonly int[] Values = typeof(T)
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Select(f => Marshal.OffsetOf<T>(f.Name).ToInt32())
+            .Append(Unsafe.SizeOf<T>())
+            .ToArray();
+    }
+
+    internal static void ReverseFieldBytes<T>(Span<byte> buffer) where T : unmanaged
+    {
+        var offsets = FieldOffsets<T>.Values;
+        for (var i = 0; i < offsets.Length - 1; ++i)
+            buffer[offsets[i]..offsets[i + 1]].Reverse();
+    }
+
     extension(Stream stream)
     {
-        public T Read<T>() where T : struct =>
+        public T Read<T>() where T : unmanaged =>
             stream.TryRead(out T @struct) ? @struct : throw new EndOfStreamException();
 
-        public bool TryRead<T>(out T @struct) where T : struct
+        public bool TryRead<T>(out T @struct) where T : unmanaged
         {
             Unsafe.SkipInit(out @struct);
             var buffer = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref @struct, 1));
             if (stream.ReadAtLeast(buffer, buffer.Length, throwOnEndOfStream: false) != buffer.Length)
                 return false;
 
-            if (BitConverter.IsLittleEndian)
-                return true;
-
-            // TODO: Does it make sense to cache this?
-            var offsets = typeof(T)
-                .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
-                .Where(f => f.GetCustomAttribute<FieldOffsetAttribute>() is not null)
-                .Select(f => Marshal.OffsetOf<T>(f.Name).ToInt32())
-                .Append(Unsafe.SizeOf<T>())
-                .ToArray();
-
-            for (var i = 0; i < offsets.Length - 1; ++i)
-                buffer[offsets[i]..offsets[i + 1]].Reverse();
+            if (!BitConverter.IsLittleEndian)
+                ReverseFieldBytes<T>(buffer);
 
             return true;
         }
 
-        public void Write<T>(T @struct) where T : struct
+        public void Write<T>(T @struct) where T : unmanaged
         {
             var buffer = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref @struct, 1));
             if (!BitConverter.IsLittleEndian)
-            {
-                // TODO: Does it make sense to cache this?
-                var offsets = typeof(T)
-                    .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
-                    .Where(f => f.GetCustomAttribute<FieldOffsetAttribute>() is not null)
-                    .Select(f => Marshal.OffsetOf<T>(f.Name).ToInt32())
-                    .Append(Unsafe.SizeOf<T>())
-                    .ToArray();
-
-                for (var i = 0; i < offsets.Length - 1; ++i)
-                    buffer[offsets[i]..offsets[i + 1]].Reverse();
-            }
+                ReverseFieldBytes<T>(buffer);
 
             stream.Write(buffer);
         }

--- a/tests/DBase.Tests/StreamExtensionsTests.cs
+++ b/tests/DBase.Tests/StreamExtensionsTests.cs
@@ -1,0 +1,166 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using DBase.Interop;
+
+namespace DBase.Tests;
+
+public class StreamExtensionsTests
+{
+    [StructLayout(LayoutKind.Explicit, Size = 4)]
+    private struct SingleField
+    {
+        [FieldOffset(0)] public int Value;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 12)]
+    private struct MultiField
+    {
+        [FieldOffset(0)] public int A;
+        [FieldOffset(4)] public short B;
+        [FieldOffset(6)] public short C;
+        [FieldOffset(8)] public int D;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 1)]
+    private struct ByteField
+    {
+        [FieldOffset(0)] public byte Value;
+    }
+
+    [Fact]
+    public void Read_SingleField_RoundTrips()
+    {
+        var expected = new SingleField { Value = 0x12345678 };
+        var stream = WriteToStream(expected);
+
+        var actual = stream.Read<SingleField>();
+
+        Assert.Equal(expected.Value, actual.Value);
+    }
+
+    [Fact]
+    public void Read_MultiField_RoundTrips()
+    {
+        var expected = new MultiField { A = 1, B = 2, C = 3, D = 4 };
+        var stream = WriteToStream(expected);
+
+        var actual = stream.Read<MultiField>();
+
+        Assert.Equal(expected.A, actual.A);
+        Assert.Equal(expected.B, actual.B);
+        Assert.Equal(expected.C, actual.C);
+        Assert.Equal(expected.D, actual.D);
+    }
+
+    [Fact]
+    public void Read_ByteField_RoundTrips()
+    {
+        var expected = new ByteField { Value = 0xAB };
+        var stream = WriteToStream(expected);
+
+        var actual = stream.Read<ByteField>();
+
+        Assert.Equal(expected.Value, actual.Value);
+    }
+
+    [Fact]
+    public void TryRead_ReturnsFalse_WhenStreamIsEmpty()
+    {
+        var stream = new MemoryStream();
+
+        var result = stream.TryRead<SingleField>(out _);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void TryRead_ReturnsFalse_WhenStreamIsTooShort()
+    {
+        var stream = new MemoryStream([0x01, 0x02]);
+
+        var result = stream.TryRead<SingleField>(out _);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Read_ThrowsEndOfStreamException_WhenStreamIsEmpty()
+    {
+        var stream = new MemoryStream();
+
+        Assert.Throws<EndOfStreamException>(() => stream.Read<SingleField>());
+    }
+
+    [Fact]
+    public void Write_ThenRead_MultipleStructs_InSequence()
+    {
+        var stream = new MemoryStream();
+        var s1 = new SingleField { Value = 42 };
+        var s2 = new SingleField { Value = -1 };
+
+        stream.Write(s1);
+        stream.Write(s2);
+        stream.Position = 0;
+
+        var r1 = stream.Read<SingleField>();
+        var r2 = stream.Read<SingleField>();
+
+        Assert.Equal(s1.Value, r1.Value);
+        Assert.Equal(s2.Value, r2.Value);
+    }
+
+    [Fact]
+    public void ReverseFieldBytes_TwiceRoundTrips()
+    {
+        var original = new MultiField { A = 0x01020304, B = 0x0506, C = 0x0708, D = 0x090A0B0C };
+        Span<byte> buffer = stackalloc byte[Unsafe.SizeOf<MultiField>()];
+        MemoryMarshal.Write(buffer, in original);
+
+        var expected = buffer.ToArray();
+
+        StreamExtensions.ReverseFieldBytes<MultiField>(buffer);
+        StreamExtensions.ReverseFieldBytes<MultiField>(buffer);
+
+        Assert.Equal(expected, buffer.ToArray());
+    }
+
+    [Fact]
+    public void ReverseFieldBytes_ReversesEachFieldIndependently()
+    {
+        var value = new MultiField { A = 0x01020304, B = 0x0506, C = 0x0708, D = 0x090A0B0C };
+        Span<byte> buffer = stackalloc byte[Unsafe.SizeOf<MultiField>()];
+        MemoryMarshal.Write(buffer, in value);
+
+        var before = buffer.ToArray();
+
+        StreamExtensions.ReverseFieldBytes<MultiField>(buffer);
+
+        // Each field's bytes should be individually reversed
+        Assert.Equal(before[0..4].Reverse().ToArray(), buffer[0..4].ToArray());   // A: int
+        Assert.Equal(before[4..6].Reverse().ToArray(), buffer[4..6].ToArray());   // B: short
+        Assert.Equal(before[6..8].Reverse().ToArray(), buffer[6..8].ToArray());   // C: short
+        Assert.Equal(before[8..12].Reverse().ToArray(), buffer[8..12].ToArray()); // D: int
+    }
+
+    [Fact]
+    public void ReverseFieldBytes_SingleByte_IsNoOp()
+    {
+        var value = new ByteField { Value = 0xAB };
+        Span<byte> buffer = stackalloc byte[Unsafe.SizeOf<ByteField>()];
+        MemoryMarshal.Write(buffer, in value);
+
+        var expected = buffer.ToArray();
+
+        StreamExtensions.ReverseFieldBytes<ByteField>(buffer);
+
+        Assert.Equal(expected, buffer.ToArray());
+    }
+
+    private static MemoryStream WriteToStream<T>(T value) where T : unmanaged
+    {
+        var stream = new MemoryStream();
+        stream.Write(value);
+        stream.Position = 0;
+        return stream;
+    }
+}


### PR DESCRIPTION
## Summary
- split DBF header processing into dedicated ReadHeader, ReadDescriptors, and ReadDbcBacklink methods
- split DBF writes into dedicated WriteHeader, WriteDescriptors, and WriteDbcBacklink methods with explicit seek positions
- refactor StreamExtensions endianness handling to reuse cached field offsets per struct type and share reversal logic
- add focused StreamExtensionsTests coverage for read/write behavior, short reads, and field-byte reversal semantics

## Validation
- dotnet test